### PR TITLE
Notebook to add mock scores to labels

### DIFF
--- a/ds_notebook/notebooks/add_mock_scores_to_mongo_labels.ipynb
+++ b/ds_notebook/notebooks/add_mock_scores_to_mongo_labels.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "72cd27f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect to MongoDB and save data\n",
+    "import pymongo\n",
+    "mongo = pymongo.MongoClient('mongodb://mongo_local:27017')\n",
+    "db = mongo['mockdata']\n",
+    "\n",
+    "patents_col = db['patents']\n",
+    "labels_col = db['labels']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "938f2360",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# build claim dependency map\n",
+    "claim_deps = {}\n",
+    "patents = patents_col.find({})\n",
+    "for patent in patents:\n",
+    "    patent_number = patent['patent_number']\n",
+    "    for claim in patent['claims']:\n",
+    "        claim_number, dep = claim['claim_number'], claim['dependencies']\n",
+    "        claim_deps[f'{patent_number}_{claim_number}'] = dep\n",
+    "        \n",
+    "def get_parent_claim_numbers(patent_number, claim_number):\n",
+    "    c_no = claim_number\n",
+    "    parents = []\n",
+    "    \n",
+    "    while True:\n",
+    "        key = f'{patent_number}_{c_no}'\n",
+    "        if key in claim_deps:\n",
+    "            value = claim_deps[key]\n",
+    "            if value is None:\n",
+    "                break\n",
+    "            else:\n",
+    "                c_no = int(value)\n",
+    "                parents.append(c_no)\n",
+    "        else:\n",
+    "            break\n",
+    "    return parents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6a6d28f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4e3fa51f-456d-4863-af4b-1e1ae5e59b72\n",
+      "73a25b94-80b8-4505-b97f-011c06157915\n",
+      "00d3c93f-4eb7-4643-bb24-15ecc707897e\n",
+      "c6b5b158-a814-411c-90f2-7a84d8814145\n",
+      "47b14a6d-d22f-4c22-bc55-861b00502928\n",
+      "eba483a8-ccb1-4147-bea8-bc7a9bc6110a\n",
+      "3fca7a7d-b89b-4143-be19-f2be942986f5\n",
+      "f5e0e912-46d8-4bd5-b0d0-34b1f77d1bc4\n",
+      "ac092db4-b7d2-457e-a757-535422a52128\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.6/site-packages/ipykernel_launcher.py:37: DeprecationWarning: update is deprecated. Use replace_one, update_one or update_many instead.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from random import random, randrange, seed\n",
+    "\n",
+    "# For each section in each label\n",
+    "# 1. Get the linked patents, select a few\n",
+    "# 2. Pick a few random claim numbers\n",
+    "# 3. Add a random score\n",
+    "\n",
+    "seed(10)\n",
+    "\n",
+    "labels = labels_col.find({})\n",
+    "for label in labels:\n",
+    "    patents = list(patents_col.find({'application_numbers': {'$in': label['application_numbers']}}))\n",
+    "    if len(patents):\n",
+    "        print(label['spl_id'])\n",
+    "        sections = []\n",
+    "        \n",
+    "        for section in label['sections']:\n",
+    "            scores = []\n",
+    "            for patent in patents:\n",
+    "                # Select up to 5 claims at random, for this section\n",
+    "                claim_nos = set()\n",
+    "                for _ in range(5):\n",
+    "                    claim_nos.add(randrange(len(patent['claims'])))\n",
+    "                # Make up scores in the range 0.5-1, for the selected claims\n",
+    "                for claim_no in claim_nos:\n",
+    "                    scores.append({\n",
+    "                        'patentNumber': patent['patent_number'],\n",
+    "                        'claimNumber': claim_no,\n",
+    "                        'parentClaimNumbers': get_parent_claim_numbers(patent['patent_number'], claim_no),\n",
+    "                        'score': round(random() / 2 + 0.5, 4)\n",
+    "                    })\n",
+    "            section['scores'] = scores\n",
+    "            sections.append(section)\n",
+    "    \n",
+    "        # Update Mongo\n",
+    "        label['sections'] = sections\n",
+    "        labels_col.update({'spl_id': label['spl_id']}, label, upsert=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f914a440",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Uses existing `labels` and `patents` collections in MongoDB, created using the steps here:
https://github.com/pharmaDB/etl_pipeline/tree/main/testdata